### PR TITLE
resolved bug when updating the text of a label-

### DIFF
--- a/JTAttributedLabel/JTAttributedLabel/JTAttributedLabel.m
+++ b/JTAttributedLabel/JTAttributedLabel/JTAttributedLabel.m
@@ -113,6 +113,7 @@
         
         self.alignmentMode = alignmentMode;
     }
+    [super setString:_string];
 }
 
 - (void)drawInContext:(CGContextRef)ctx {


### PR DESCRIPTION
Added a missing call to [super setString:] .

This fixes a bug where the label's text was not refreshed if we updated the "attributedText" property.
