### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ So its in different data structure than the CoreText compliment. I realized I ha
 So after all that, I create a subclass of `UILabel` with a `CATextLayer` to layout the NSAttributeString. And now we've a light weight but imperfect implementation.
 
 
-Usage (Cocoapods)
+Usage (CocoaPods)
 -----------------
 
-Install via Cocoapods, thanks [blakewatters](https://github.com/blakewatters/) for making it happen!
+Install via CocoaPods, thanks [blakewatters](https://github.com/blakewatters/) for making it happen!
 
 
 Usage


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
